### PR TITLE
fix: Support for empty string in value in adding edges, vertex and properties

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -42,6 +42,10 @@ describe('quoteAndCombine', () => {
         "'zach', 'ryan', 'lola'",
       )
     })
+
+    it('quotes a single argument which is empty string', () => {
+      expect(quoteAndCombine('')).toEqual("''");
+    })
   })
 
   describe('when explicitly passing an array', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,13 +2,13 @@ export function isAPromise(obj: any): boolean {
   return obj.then && typeof obj.then === 'function'
 }
 
-export function quoteAndCombine(...args) {
+export function quoteAndCombine(...args: (string | number | boolean | any[])[]) {
   if (Array.isArray(args[0])) {
     args = args[0]
   }
 
   return args
-    .filter(arg => arg)
-    .map(arg => `'${arg}'`)
+    .filter((arg) => arg === '' ? `''` : arg)
+    .map(arg => arg === '' ? `''` : `'${arg}'`)
     .join(', ')
 }


### PR DESCRIPTION
Support to add empty string values in the property function. As Azure cosmos graph support empty string values this package should also allow to use that.