### PR TITLE
fix(quote-and-combine):  Support empty string in value in .property()

### DIFF
--- a/src/query.test.ts
+++ b/src/query.test.ts
@@ -122,6 +122,14 @@ describe('.property()', () => {
     let q = Query.g.property({foo: 'bar', bar: undefined})
     expect(q.toString()).toBe("g.property('foo', 'bar')")
   })
+
+  it('allows empty string as property value', () => {
+    let q1 = Query.g.property('foo', '')
+    expect(q1.toString()).toBe("g.property('foo', '')")
+  
+    let q2 = Query.g.property({bar: ''})
+    expect(q2.toString()).toBe("g.property('bar', '')")
+  })
 })
 
 describe('.as()', () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -42,6 +42,10 @@ describe('quoteAndCombine', () => {
         "'zach', 'ryan', 'lola'",
       )
     })
+
+    it('quotes a single argument which is empty string', () => {
+      expect(quoteAndCombine('')).toEqual("''");
+    })
   })
 
   describe('when explicitly passing an array', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,13 +2,13 @@ export function isAPromise(obj: any): boolean {
   return obj.then && typeof obj.then === 'function'
 }
 
-export function quoteAndCombine(...args) {
+export function quoteAndCombine(...args: (string | number | boolean | any[])[]) {
   if (Array.isArray(args[0])) {
     args = args[0]
   }
 
   return args
-    .filter(arg => arg)
-    .map(arg => `'${arg}'`)
+    .filter((arg) => arg === '' ? `''` : arg)
+    .map(arg => arg === '' ? `''` : `'${arg}'`)
     .join(', ')
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,13 +2,13 @@ export function isAPromise(obj: any): boolean {
   return obj.then && typeof obj.then === 'function'
 }
 
-export function quoteAndCombine(...args: (string | number | boolean | any[])[]) {
+export function quoteAndCombine(...args: Array<string | number | boolean | any[]>) {
   if (Array.isArray(args[0])) {
     args = args[0]
   }
 
   return args
-    .filter((arg) => arg === '' ? `''` : arg)
+    .filter((arg) => arg === '' || arg)
     .map(arg => arg === '' ? `''` : `'${arg}'`)
     .join(', ')
 }


### PR DESCRIPTION
Fixed bug where empty string was not allowed to be passed in addV, addE and property functions.